### PR TITLE
Centralize API base path configuration

### DIFF
--- a/lib/features/Loans/views/viewLoan.dart
+++ b/lib/features/Loans/views/viewLoan.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:sanaa_fi_saas/features/Loans/controllers/allLoansControllers.dart';
+import 'package:sanaa_fi_saas/utils/app_constants.dart';
 
 class ViewLoan extends StatelessWidget {
   final AllLoansController loanController = Get.find<AllLoansController>();
@@ -60,7 +61,7 @@ class ViewLoan extends StatelessWidget {
               radius: 22,
               backgroundImage: client.clientPhoto != null
                   ? NetworkImage(client.clientPhoto)  // Client's photo
-                  : const NetworkImage('https://lendsup.sanaa.co/public/assets/admin/img/160x160/img1.jpg'),
+                  : NetworkImage(AppConstants.baseUrl + '/public/assets/admin/img/160x160/img1.jpg'),
             ),
             const SizedBox(width: 10),
             Text(client.name ?? 'Client', style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),

--- a/lib/features/auth/controllers/auth_controller.dart
+++ b/lib/features/auth/controllers/auth_controller.dart
@@ -294,7 +294,7 @@ Future<void> getUserByPhone(String phone) async {
     print("_____________\n____Requesting customer by phone:__________\n__________\n__________\n__________\n");
 
     // Define the URL for the POST request
-    final url = Uri.parse('https://lendsup.sanaa.co/api/v1/getUserByPhone');
+    final url = Uri.parse('${AppConstants.baseUrl}${AppConstants.apiPath}/getUserByPhone');
 
     // Make the POST request, sending the phone number in the body
     final response = await http.post(

--- a/lib/features/clients/views/ClientProfile.dart
+++ b/lib/features/clients/views/ClientProfile.dart
@@ -3,6 +3,7 @@ import 'package:get/get.dart';
 import 'package:intl/intl.dart';
 import 'package:sanaa_fi_saas/features/clients/controller/client_profile_controller.dart';
 import 'package:sanaa_fi_saas/features/clients/data/client_profile.dart';
+import 'package:sanaa_fi_saas/utils/app_constants.dart';
 
 class ClientProfile extends StatelessWidget {
   ClientProfile({Key? key}) : super(key: key);
@@ -71,7 +72,7 @@ class ClientProfile extends StatelessWidget {
                         radius: 45,
                         backgroundImage: NetworkImage(
                           clientData.client?.clientPhoto ??
-                              'https://lendsup.sanaa.co/public/assets/admin/img/160x160/img1.jpg',
+                              '${AppConstants.baseUrl}/public/assets/admin/img/160x160/img1.jpg',
                         ),
                       ),
                       const SizedBox(width: 20),
@@ -278,7 +279,7 @@ class ClientProfile extends StatelessWidget {
         CircleAvatar(
           radius: 35,
           backgroundImage: NetworkImage(
-            agent.imageFullpath ?? 'https://lendsup.sanaa.co/public/assets/admin/img/160x160/img1.jpg',
+            agent.imageFullpath ?? '${AppConstants.baseUrl}/public/assets/admin/img/160x160/img1.jpg',
           ),
         ),
         const SizedBox(width: 10),

--- a/lib/features/clients/views/client_profile_screen.dart
+++ b/lib/features/clients/views/client_profile_screen.dart
@@ -3,6 +3,7 @@ import 'package:get/get.dart';
 import 'package:intl/intl.dart';
 import 'package:sanaa_fi_saas/features/clients/controller/client_profile_controller.dart';
 import 'package:sanaa_fi_saas/features/clients/data/client_profile.dart';
+import 'package:sanaa_fi_saas/utils/app_constants.dart';
 
 class ClientProfileScreen extends StatelessWidget {
   final int clientId;
@@ -66,8 +67,8 @@ class ClientProfileScreen extends StatelessWidget {
                       CircleAvatar(
                         radius: 45,
                         backgroundImage: NetworkImage(
-                          clientData.client?.clientPhoto ?? 
-                          'https://lendsup.sanaa.co/public/assets/admin/img/160x160/img1.jpg',
+                          clientData.client?.clientPhoto ??
+                          '${AppConstants.baseUrl}/public/assets/admin/img/160x160/img1.jpg',
                         ),
                       ),
                       const SizedBox(width: 20),
@@ -258,7 +259,7 @@ class ClientProfileScreen extends StatelessWidget {
         CircleAvatar(
           radius: 35,
           backgroundImage: NetworkImage(
-            agent.imageFullpath ?? 'https://lendsup.sanaa.co/public/assets/admin/img/160x160/img1.jpg',
+            agent.imageFullpath ?? '${AppConstants.baseUrl}/public/assets/admin/img/160x160/img1.jpg',
           ),
         ),
         const SizedBox(width: 10),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:get_storage/get_storage.dart';
 import 'package:sanaa_fi_saas/data/api/api_client.dart';
+import 'package:sanaa_fi_saas/utils/app_constants.dart';
 import 'package:sanaa_fi_saas/features/Loans/controllers/LoanController.dart';
 import 'package:sanaa_fi_saas/features/Loans/controllers/allLoansControllers.dart';
 import 'package:sanaa_fi_saas/features/Loans/controllers/loans_dashboard_controller.dart';
@@ -34,7 +35,7 @@ Future<void> main() async {
 
   // Register ApiClient
   Get.lazyPut<ApiClient>(() => ApiClient(
-        appBaseUrl: 'https://lendsup.sanaa.co/api/v1',
+        appBaseUrl: AppConstants.baseUrl + AppConstants.apiPath,
         sharedPreferences: sharedPreferences,
         deiceInfo: deviceInfo,
         uniqueId: uniqueId,

--- a/lib/utils/app_constants.dart
+++ b/lib/utils/app_constants.dart
@@ -7,6 +7,7 @@ class AppConstants {
   static const String appName = 'Field Agent';
   // static const String baseUrl = 'https://finmicro.sanaa.co';
   static const String baseUrl = 'https://lendsup.sanaa.co';
+  static const String apiPath = '/api/v1';
   static const bool demo = false;
   static const double appVersion = 4.3;
 


### PR DESCRIPTION
## Summary
- expose `apiPath` constant in `AppConstants`
- use `baseUrl` + `apiPath` when creating `ApiClient`
- access default images and auth URL via `AppConstants`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68608a7cf6388324badcfc259c58dff4