### PR TITLE
Fix UI responsiveness

### DIFF
--- a/lib/base/custom_large_button.dart
+++ b/lib/base/custom_large_button.dart
@@ -26,7 +26,8 @@ class CustomLargeButton extends StatelessWidget {
       child: TextButton(
         onPressed: onTap as void Function()?,
         style: TextButton.styleFrom(
-          minimumSize: MediaQuery.of(context).size,
+          minimumSize: Size(MediaQuery.of(context).size.width,
+              MediaQuery.of(context).size.height * 0.5),
           padding: const EdgeInsets.symmetric(
               vertical: Dimensions.paddingSizeDefault),
           backgroundColor: backgroundColor,

--- a/lib/base/no_data_screen.dart
+++ b/lib/base/no_data_screen.dart
@@ -9,7 +9,7 @@ class NoDataFoundScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return fromHome! ?  noDataWidget(context) : SizedBox(height: MediaQuery.of(context).size.height * 0.6, child: noDataWidget(context));
+    return fromHome! ?  noDataWidget(context) : SizedBox(height: MediaQuery.of(context).size.height * 0.5, child: noDataWidget(context));
   }
 
   Padding noDataWidget(BuildContext context) {

--- a/lib/common/widgets/custom_large_widget.dart
+++ b/lib/common/widgets/custom_large_widget.dart
@@ -26,7 +26,8 @@ class CustomLargeButtonWidget extends StatelessWidget {
       child: TextButton(
         onPressed: onTap as void Function()?,
         style: TextButton.styleFrom(
-          minimumSize: MediaQuery.of(context).size,
+          minimumSize: Size(MediaQuery.of(context).size.width,
+              MediaQuery.of(context).size.height * 0.5),
           padding: const EdgeInsets.symmetric(
               vertical: Dimensions.paddingSizeDefault),
           backgroundColor: backgroundColor,

--- a/lib/common/widgets/no_data_widget.dart
+++ b/lib/common/widgets/no_data_widget.dart
@@ -12,7 +12,7 @@ class NoDataFoundWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return fromHome! ?  noDataWidget(context) : SizedBox(height: MediaQuery.of(context).size.height * 0.6, child: noDataWidget(context));
+    return fromHome! ?  noDataWidget(context) : SizedBox(height: MediaQuery.of(context).size.height * 0.5, child: noDataWidget(context));
   }
 
   Padding noDataWidget(BuildContext context) {

--- a/lib/features/auth/screens/login_screen.dart
+++ b/lib/features/auth/screens/login_screen.dart
@@ -79,7 +79,8 @@ class _LoginScreenState extends State<LoginScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: GetBuilder<AuthController>(builder: (authController) => AbsorbPointer(
+      body: SafeArea(
+        child: GetBuilder<AuthController>(builder: (authController) => AbsorbPointer(
         absorbing: authController.isLoading,
         child: Stack(children: [
           Column(


### PR DESCRIPTION
## Summary
- wrap login screen in SafeArea
- resize NoData widget containers for small screens
- make large button minimum size half the screen for better responsiveness

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68608eb82c2c8324a09d63ce64f9e926