### PR TITLE
Add connectivity check service

### DIFF
--- a/lib/features/splash/screens/splash_screen.dart
+++ b/lib/features/splash/screens/splash_screen.dart
@@ -27,11 +27,26 @@ class _SplashScreenState extends State<SplashScreen> with WidgetsBindingObserver
 
     bool isFirstTime = true;
 
-     subscription = Connectivity().onConnectivityChanged.listen((List<ConnectivityResult> result) async {
-      if(await ApiChecker.isVpnActive()) {
-        showCustomSnackBarHelper('you are using vpn', isVpn: true, duration: const Duration(minutes: 10));
+    // Check current connectivity status and warn if offline
+    Connectivity().checkConnectivity().then((result) {
+      if (result == ConnectivityResult.none) {
+        showCustomSnackBarHelper('No internet connection');
       }
-      if(isFirstTime) {
+    });
+
+    subscription = Connectivity()
+        .onConnectivityChanged
+        .listen((List<ConnectivityResult> result) async {
+      if (await ApiChecker.isVpnActive()) {
+        showCustomSnackBarHelper('you are using vpn',
+            isVpn: true, duration: const Duration(minutes: 10));
+      }
+      bool connected =
+          result.isNotEmpty && result.first != ConnectivityResult.none;
+      if (!connected) {
+        showCustomSnackBarHelper('No internet connection');
+      }
+      if (isFirstTime) {
         isFirstTime = false;
         await _route();
       }
@@ -45,6 +60,7 @@ class _SplashScreenState extends State<SplashScreen> with WidgetsBindingObserver
 
   @override
   void dispose() {
+    subscription.cancel();
     super.dispose();
   }
 

--- a/lib/helper/network_info.dart
+++ b/lib/helper/network_info.dart
@@ -1,33 +1,21 @@
-// import 'package:connectivity_plus/connectivity_plus.dart';
-// import 'package:flutter/material.dart';
-// import 'package:get/get.dart';
-// // import 'package:sanaa_fi_saas/controller/splash_controller.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:get/get.dart';
+import 'package:sanaa_fi_saas/helper/custom_snackbar_helper.dart';
 
-// class NetworkInfo {
-//   final Connectivity connectivity;
-//   NetworkInfo(this.connectivity);
+class NetworkInfo extends GetxService {
+  final Connectivity connectivity;
+  NetworkInfo(this.connectivity);
 
-//   Future<bool> get isConnected async {
-//     ConnectivityResult result = await connectivity.checkConnectivity();
-//     return result != ConnectivityResult.none;
-//   }
+  Future<bool> get isConnected async {
+    ConnectivityResult result = await connectivity.checkConnectivity();
+    return result != ConnectivityResult.none;
+  }
 
-//   static void checkConnectivity(BuildContext context) {
-//     Connectivity().onConnectivityChanged.listen((ConnectivityResult result) {
-//       if(Get.find<SplashController>().firstTimeConnectionCheck) {
-//         Get.find<SplashController>().setFirstTimeConnectionCheck(false);
-//       }else {
-//         bool isNotConnected = result == ConnectivityResult.none;
-//         isNotConnected ? const SizedBox() : ScaffoldMessenger.of(context).hideCurrentSnackBar();
-//         ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-//           backgroundColor: isNotConnected ? Colors.red : Colors.green,
-//           duration: Duration(seconds: isNotConnected ? 6000 : 3),
-//           content: Text(
-//             isNotConnected ? 'no_connection' : 'connected',
-//             textAlign: TextAlign.center,
-//           ),
-//         ));
-//       }
-//     });
-//   }
-// }
+  void initConnectionCheck() {
+    connectivity.onConnectivityChanged.listen((ConnectivityResult result) {
+      if (result == ConnectivityResult.none) {
+        showCustomSnackBarHelper('No internet connection');
+      }
+    });
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,6 +21,8 @@ import 'package:sanaa_fi_saas/features/home/views/home.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:uuid/uuid.dart';
 import 'package:device_info_plus/device_info_plus.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:sanaa_fi_saas/helper/network_info.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -75,6 +77,10 @@ Future<void> main() async {
     Get.lazyPut(() => LoanController(loanRepo: Get.find()));
     Get.lazyPut(() => AllLoansController(loanRepo: Get.find()));
       // Get.lazyPut(() => NotificationController(notificationRepo: Get.find()));
+
+  // Initialize connectivity checker
+  final networkInfo = Get.put(NetworkInfo(Connectivity()));
+  networkInfo.initConnectionCheck();
 
 
 


### PR DESCRIPTION
## Summary
- show a snackbar if no internet connection
- cancel connectivity subscription when the splash screen disposes
- create `NetworkInfo` service to monitor connectivity
- register the network service in `main.dart`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860ac0fd4e483249a25daec89232011