### PR TITLE
Implement basic desktop auth structure

### DIFF
--- a/lib/data/api/api_client.dart
+++ b/lib/data/api/api_client.dart
@@ -262,11 +262,21 @@ class ApiClient extends GetxService {
      }else if(response0.statusCode != 200 && response0.body == null) {
        response0 = Response(statusCode: 0, statusText: noInternetMessage);
      }
-     debugPrint('====> API Response: [${response0.statusCode}] $uri\n${response0.body}');
-     return response0;
-   }
+    debugPrint('====> API Response: [${response0.statusCode}] $uri\n${response0.body}');
+    return response0;
+  }
 
- }
+  // ---------------- Desktop Helpers -----------------
+  void updateDesktopHeaders(String token, String fingerprint) {
+    _mainHeaders?['Authorization'] = 'Bearer $token';
+    _mainHeaders?['X-Device-Fingerprint'] = fingerprint;
+  }
+
+  void setupAuthInterceptor() {
+    // Placeholder for interceptor implementation
+  }
+
+}
 class MultipartBody {
   String key;
   File? file;

--- a/lib/data/repository/auth_repo.dart
+++ b/lib/data/repository/auth_repo.dart
@@ -4,14 +4,17 @@ import 'package:flutter/cupertino.dart';
 // import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:get/get.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:get_storage/get_storage.dart';
 import 'package:sanaa_fi_saas/data/api/api_client.dart';
 import 'package:sanaa_fi_saas/data/model/response/user_data.dart';
 import 'package:sanaa_fi_saas/utils/app_constants.dart';
 
 
 class AuthRepo extends GetxService{
-   final ApiClient apiClient;
+  final ApiClient apiClient;
   final SharedPreferences sharedPreferences;
+  final GetStorage desktopStorage = GetStorage();
+
   AuthRepo({required this.apiClient, required this.sharedPreferences});
 
 
@@ -198,9 +201,61 @@ class AuthRepo extends GetxService{
 
    void removeUserData()=> sharedPreferences.remove(AppConstants.userData);
 
-   String getUserData() {
-     return sharedPreferences.getString(AppConstants.userData) ?? '';
-   }
+  String getUserData() {
+    return sharedPreferences.getString(AppConstants.userData) ?? '';
+  }
+
+  // ---------------- Desktop Authentication -----------------
+  Future<Response> desktopLogin({String? email, String? password, bool rememberMe = false, String? deviceFingerprint}) async {
+    return await apiClient.postData(AppConstants.desktopLogin, {
+      'email': email,
+      'password': password,
+      'remember_me': rememberMe,
+      'device_fingerprint': deviceFingerprint,
+    });
+  }
+
+  Future<Response> desktopLogout() async {
+    return await apiClient.postData(AppConstants.desktopLogout, {});
+  }
+
+  Future<Response> desktopLogoutAll() async {
+    return await apiClient.postData(AppConstants.desktopLogoutAll, {});
+  }
+
+  Future<Response> refreshDesktopToken() async {
+    return await apiClient.postData(AppConstants.desktopRefresh, {});
+  }
+
+  Future<Response> verifyDesktopToken() async {
+    return await apiClient.getData(AppConstants.desktopVerify);
+  }
+
+  Future<Response> getSessionInfo() async {
+    return await apiClient.getData(AppConstants.desktopSession);
+  }
+
+  Future<bool> saveDesktopToken(String token, int sessionId) async {
+    apiClient.token = token;
+    apiClient.updateHeader(token);
+    desktopStorage.write(AppConstants.desktopAuthToken, token);
+    desktopStorage.write(AppConstants.desktopSessionId, sessionId);
+    return true;
+  }
+
+  String? getDesktopToken() {
+    return desktopStorage.read(AppConstants.desktopAuthToken);
+  }
+
+  int? getSessionId() {
+    return desktopStorage.read(AppConstants.desktopSessionId);
+  }
+
+  Future<void> clearDesktopAuth() async {
+    await desktopStorage.remove(AppConstants.desktopAuthToken);
+    await desktopStorage.remove(AppConstants.desktopSessionId);
+    await desktopStorage.remove(AppConstants.desktopUserEmail);
+  }
 
 
 

--- a/lib/features/auth/controllers/desktop_auth_controller.dart
+++ b/lib/features/auth/controllers/desktop_auth_controller.dart
@@ -1,0 +1,136 @@
+import 'dart:async';
+import 'package:get/get.dart';
+import 'package:sanaa_fi_saas/data/repository/auth_repo.dart';
+import 'package:sanaa_fi_saas/services/desktop_session_storage.dart';
+import 'package:sanaa_fi_saas/services/device_fingerprint_service.dart';
+import '../utils/auth_error_handler.dart';
+
+class DesktopAuthController extends GetxController {
+  final AuthRepo authRepo;
+  DesktopAuthController({required this.authRepo});
+
+  RxBool isAuthenticated = false.obs;
+  RxInt remainingSeconds = 0.obs;
+  RxBool isRefreshing = false.obs;
+  RxString userEmail = ''.obs;
+
+  Timer? sessionCheckTimer;
+  Timer? autoRefreshTimer;
+
+  Future<void> login({required String email, required String password, bool rememberMe = false}) async {
+    final fingerprint = await DeviceFingerprintService.generateFingerprint();
+    final response = await authRepo.desktopLogin(email: email, password: password, rememberMe: rememberMe, deviceFingerprint: fingerprint);
+    if (response.statusCode == 200) {
+      final token = response.body['token'];
+      final sessionId = response.body['session_id'];
+      await DesktopSessionStorage.saveSession(token, sessionId, email);
+      authRepo.apiClient.updateDesktopHeaders(token, fingerprint);
+      isAuthenticated.value = true;
+      userEmail.value = email;
+      await startSessionMonitoring();
+    } else {
+      AuthErrorHandler.handleLoginError(response.body);
+    }
+  }
+
+  Future<void> logout() async {
+    await authRepo.desktopLogout();
+    await DesktopSessionStorage.clearSession();
+    isAuthenticated.value = false;
+    sessionCheckTimer?.cancel();
+    autoRefreshTimer?.cancel();
+  }
+
+  Future<void> logoutAllDevices() async {
+    await authRepo.desktopLogoutAll();
+    await DesktopSessionStorage.clearSession();
+    isAuthenticated.value = false;
+  }
+
+  Future<void> startSessionMonitoring() async {
+    sessionCheckTimer?.cancel();
+    await checkSessionStatus();
+    sessionCheckTimer = Timer.periodic(const Duration(seconds: 30), (_) => checkSessionStatus());
+  }
+
+  Future<void> refreshToken() async {
+    if (isRefreshing.value) return;
+    isRefreshing.value = true;
+    try {
+      final response = await authRepo.refreshDesktopToken();
+      if (response.statusCode == 200) {
+        final token = response.body['token'];
+        final sessionId = response.body['session_id'];
+        await DesktopSessionStorage.saveSession(token, sessionId, userEmail.value);
+        final fp = await DeviceFingerprintService.getStoredFingerprint() ?? await DeviceFingerprintService.generateFingerprint();
+        authRepo.apiClient.updateDesktopHeaders(token, fp);
+        scheduleTokenRefresh();
+      } else {
+        AuthErrorHandler.handleTokenRefreshError(response.body);
+      }
+    } finally {
+      isRefreshing.value = false;
+    }
+  }
+
+  Future<void> checkSessionStatus() async {
+    final response = await authRepo.getSessionInfo();
+    if (response.statusCode == 200) {
+      remainingSeconds.value = response.body['remaining_seconds'];
+      scheduleTokenRefresh();
+    } else if (response.statusCode == 401) {
+      handleSessionExpiry();
+    }
+  }
+
+  void scheduleTokenRefresh() {
+    autoRefreshTimer?.cancel();
+    final refreshIn = remainingSeconds.value - 120;
+    if (refreshIn > 0) {
+      autoRefreshTimer = Timer(Duration(seconds: refreshIn), () {
+        refreshToken();
+      });
+    }
+  }
+
+  void handleSessionExpiry() {
+    logout();
+  }
+
+  Future<void> checkExistingSession() async {
+    if (await DesktopSessionStorage.hasValidSession()) {
+      final session = await DesktopSessionStorage.getSession();
+      if (session != null) {
+        userEmail.value = session.email;
+        final fp = await DeviceFingerprintService.getStoredFingerprint() ?? await DeviceFingerprintService.generateFingerprint();
+        authRepo.apiClient.updateDesktopHeaders(session.token, fp);
+        isAuthenticated.value = true;
+        await startSessionMonitoring();
+      }
+    }
+  }
+
+  Future<void> handleRememberMe(bool remember) async {
+    if (remember) {
+      // TODO: store credentials securely
+    } else {
+      // TODO: clear stored credentials
+    }
+  }
+
+  void setupActivityMonitoring() {
+    // TODO: implement user activity based refresh
+  }
+}
+
+// Handles connectivity changes and queues refresh calls when back online
+class NetworkAwareAuthController extends DesktopAuthController {
+  NetworkAwareAuthController({required super.authRepo});
+
+  @override
+  void onInit() {
+    super.onInit();
+    // TODO: listen to connectivity changes and handle offline mode
+  }
+}
+*** End Patch

--- a/lib/features/auth/screens/login_screen.dart
+++ b/lib/features/auth/screens/login_screen.dart
@@ -1,271 +1,64 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
-// import 'package:flutter_fgbg/flutter_fgbg.dart';
-// import 'package:flutter_svg/flutter_svg.dart';
 import 'package:get/get.dart';
-import 'package:sanaa_fi_saas/features/auth/controllers/auth_controller.dart';
-// import 'package:sanaa_fi_saas/features/home/controllers/menu_controller.dart';
-// import 'package:sanaa_fi_saas/features/setting/controllers/profile_screen_controller.dart';
-import 'package:sanaa_fi_saas/features/auth/domain/models/user_short_data_model.dart';
-import 'package:sanaa_fi_saas/helper/route_helper.dart';
-import 'package:sanaa_fi_saas/utils/color_resources.dart';
-import 'package:sanaa_fi_saas/utils/dimensions.dart';
-import 'package:sanaa_fi_saas/utils/styles.dart';
-import 'package:sanaa_fi_saas/common/widgets/appbar_header_widget.dart';
-import 'package:sanaa_fi_saas/common/widgets/custom_country_code_widget.dart';
-import 'package:sanaa_fi_saas/common/widgets/custom_password_field_widget.dart';
-import 'package:sanaa_fi_saas/helper/custom_snackbar_helper.dart';
-import 'package:sanaa_fi_saas/features/auth/widgets/qr_code_popup_widget.dart';
-// import 'package:sanaa_fi_saas/helper/tween_helper.dart';
-import 'package:sanaa_fi_saas/common/widgets/hero_dialogue_route_widget.dart';
-
+import '../controllers/desktop_auth_controller.dart';
 
 class LoginScreen extends StatefulWidget {
-  final String? phoneNumber;
-  final String? countryCode;
+  const LoginScreen({super.key});
 
-  const LoginScreen({Key? key, this.phoneNumber, this.countryCode}) : super(key: key);
   @override
   State<LoginScreen> createState() => _LoginScreenState();
 }
 
 class _LoginScreenState extends State<LoginScreen> {
-  TextEditingController phoneController = TextEditingController();
-  TextEditingController  passwordController = TextEditingController();
-  FocusNode phoneFocus = FocusNode();
-  FocusNode passFocus = FocusNode();
-  final String _heroQrTag = 'hero-qr-tag';
-  String? _countryCode;
-  UserShortDataModel? userData;
-  // StreamSubscription<FGBGType>? subscription;
-
-
-  void setCountryCode(String code){
-    _countryCode = code;
-  }
-  void setInitialCountryCode(String? code){
-    _countryCode = code;
-  }
-
-  @override
-  void initState() {
-    super.initState();
-
-    // subscription = FGBGEvents.stream.listen((event) {
-    //   if(event == FGBGType.foreground) {
-    //     Get.find<AuthController>().authenticateWithBiometric(true,  null);
-    //   }
-    // });
-
-    userData = Get.find<AuthController>().getUserData();
-    if(widget.phoneNumber != userData?.phone) {
-      Get.find<AuthController>().removeUserData();
-      userData = null;
-    }
-
-    Get.find<AuthController>().authenticateWithBiometric(true, null);
-
-    setInitialCountryCode(widget.countryCode);
-    phoneController.text = widget.phoneNumber!;
-  }
-
-  @override
-  void dispose() {
-    // subscription?.cancel();
-    super.dispose();
-  }
+  final TextEditingController emailController = TextEditingController();
+  final TextEditingController passwordController = TextEditingController();
+  bool rememberMe = false;
 
   @override
   Widget build(BuildContext context) {
+    final controller = Get.find<DesktopAuthController>();
     return Scaffold(
-      body: SafeArea(
-        child: GetBuilder<AuthController>(builder: (authController) => AbsorbPointer(
-        absorbing: authController.isLoading,
-        child: Stack(children: [
-          Column(
-            children: [
-            Expanded(flex: 5, child: Container(color: Theme.of(context).primaryColor)),
-
-            Expanded(flex: 5, child: Container(color: Theme.of(context).cardColor))
-          ]),
-
-          const Positioned(
-            top: Dimensions.paddingSizeOverLarge,
-            left: 0, right: 0,
-            child: AppBarHeaderWidget(),
-          ),
-            Positioned(
-              top: 135,
-              left: 0,
-              right: 0,
-              bottom: 0,
-              child: Container(
-                padding: const EdgeInsets.only(left: Dimensions.paddingSizeExtraExtraLarge, right: Dimensions.paddingSizeLarge, top: Dimensions.paddingSizeExtraExtraLarge,),
-                width: double.infinity,
-                decoration: BoxDecoration(color: Theme.of(context).cardColor, borderRadius: const BorderRadius.only(topLeft: Radius.circular(Dimensions.radiusSizeExtraExtraLarge), topRight: Radius.circular(Dimensions.radiusSizeExtraExtraLarge),),
-                ),
-                child: SingleChildScrollView(
-                  child: Column(
-                    children: [
-                      GetBuilder<AuthController>(builder: (controller){
-                        return Row(
-                          children: [
-                            Column(
-                              crossAxisAlignment: CrossAxisAlignment.start, mainAxisSize: MainAxisSize.min,
-                              children: [
-                                Text('welcome_back'.tr, textAlign: TextAlign.center,
-                                  style: rubikLight.copyWith(color: Theme.of(context).textTheme.titleLarge!.color,
-                                    fontSize: Dimensions.fontSizeLarge,),),
-
-                                userData?.name != null ?
-                                SizedBox(width: MediaQuery.of(context).size.width * 0.6,
-                                  child: Text(
-                                    userData?.name ?? '',
-                                    textAlign: TextAlign.start, maxLines: 1, overflow: TextOverflow.ellipsis,
-                                    style: rubikMedium.copyWith(color: Theme.of(context).textTheme.titleLarge!.color, fontSize: Dimensions.fontSizeExtraOverLarge,),
-
-                                  ),
-                                ) : Text('user'.tr,
-                                  overflow: TextOverflow.clip, textAlign: TextAlign.center,
-                                  style: rubikMedium.copyWith(color: Theme.of(context).textTheme.titleLarge!.color, fontSize: Dimensions.fontSizeExtraOverLarge,
-                                  ),
-                                ),
-                              ],
-                            ),
-                            const Spacer(),
-
-                            SizedBox(height: 50, width: 50, child: Stack(children: [
-                              GetBuilder<AuthController>(builder: (controller){
-                                return userData?.qrCode != null ? InkWell(
-                                    // onTap: ()=> Navigator.of(context).push(HeroDialogRouteWidget(builder: (_)=> const QrCodePopupWidget())),
-                                    child: Hero(
-                                      tag: _heroQrTag,
-                                      // createRectTween: (begin, end)=> TweenHelper(begin: begin,end: end),
-                                      child: Container(
-                                        padding: const EdgeInsets.all(2),
-                                        color: Colors.white,
-                                        // child: SvgPicture.string(userData!.qrCode!),
-                                      ),
-                                    )
-                                ) : Container();
-
-                              }),
-
-                            ])),
-
-                          ],
-                        );
-                      }),
-                      const SizedBox(height: Dimensions.paddingSizeDefault,),
-                      Row(
-                        children: [
-                          Text('account'.tr, style: rubikLight.copyWith(color: Theme.of(context).textTheme.bodyLarge!.color!.withOpacity(0.9), fontSize: Dimensions.fontSizeLarge)),
-                          Expanded(
-                            child: TextField(
-                              controller: phoneController,
-                              focusNode: phoneFocus,
-                              onSubmitted: (value) {
-                                FocusScope.of(context).requestFocus(passFocus);
-                              },
-                              keyboardType: TextInputType.phone,
-                              decoration: InputDecoration(
-                                  border: InputBorder.none,
-                                  contentPadding: const EdgeInsets.only(top: 14),
-                                  prefixIcon: CustomCountryCodeWidget(
-                                    initSelect: widget.countryCode,
-                                    onChanged: (countryCode)=> setCountryCode(countryCode.dialCode!),
-                                  )
-                              ),
-                            ),
-                          )
-                        ],
-                      ),
-                      Divider(
-                        color: Theme.of(context).textTheme.titleLarge!.color!.withOpacity(0.4),
-                        height: 0.5,
-                      ),
-                      Container(
-                        padding: const EdgeInsets.only(
-                            top: Dimensions.paddingSizeExtraExtraLarge,
-                            right: Dimensions.paddingSizeSmall),
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text('4_digit_pin'.tr, style: rubikMedium.copyWith(color: Theme.of(context).textTheme.titleLarge!.color, fontSize: Dimensions.fontSizeLarge,),),
-                            const SizedBox(height: Dimensions.paddingSizeLarge,),
-                            CustomPasswordFieldWidget(
-                              hint: '＊＊＊＊',
-                              controller: passwordController,
-                              focusNode: passFocus,
-                              isShowSuffixIcon: true,
-                              isPassword: true,
-                              isIcon: false,
-                              textAlign: TextAlign.center,
-
-                            ),
-                            InkWell(
-                              onTap: ()=> Get.toNamed(''
-                              //   RouteHelper.getForgetPassRoute(
-                              //   countryCode: _countryCode,
-                              //   phoneNumber: phoneController.text.trim(),
-                              // )
-                              ),
-                              child: Text('${'forget_pin'.tr}?', style: rubikRegular.copyWith(color: Theme.of(context).colorScheme.error.withOpacity(0.7), fontSize: Dimensions.fontSizeLarge,),),
-                            ),
-                          ],
-                        ),
-                      ),
-                      const SizedBox(height: Dimensions.paddingSizeExtraOverLarge),
-                    ],
-                  ),
-                ),
-              ),
+      appBar: AppBar(title: const Text('Login')),
+      body: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          children: [
+            TextField(
+              controller: emailController,
+              decoration: const InputDecoration(labelText: 'Email'),
+              onSubmitted: (_) => _submit(),
             ),
+            const SizedBox(height: 10),
+            TextField(
+              controller: passwordController,
+              decoration: const InputDecoration(labelText: 'Password'),
+              obscureText: true,
+              onSubmitted: (_) => _submit(),
+            ),
+            Row(
+              children: [
+                Checkbox(value: rememberMe, onChanged: (v) { setState(() { rememberMe = v ?? false; }); }),
+                const Text('Remember me'),
+              ],
+            ),
+            const SizedBox(height: 20),
+            Obx(() => controller.isRefreshing.value
+                ? const CircularProgressIndicator()
+                : ElevatedButton(
+                    onPressed: _submit,
+                    child: const Text('Login'),
+                  )),
           ],
         ),
-      )),
-      floatingActionButton: Padding(
-          padding: const EdgeInsets.only(bottom: 20, right: 10),
-          child: GetBuilder<AuthController>(builder: (controller) {
-              return FloatingActionButton(
-                onPressed: () {
-                  _login(context);
-                },
-                elevation: 0, backgroundColor: Theme.of(context).secondaryHeaderColor,
-                child: controller.isLoading
-                    ? CircularProgressIndicator(color: Theme.of(context).textTheme.bodyLarge!.color,)
-                    : SizedBox(child: Icon(Icons.arrow_forward,color: ColorResources.blackColor,size: 28,),),
-              );
-            },
-          )),
+      ),
     );
   }
 
-  Future<void> _login( BuildContext context) async {
-    // Get.find<MenuItemController>().resetNavBarTabIndex();
-    String? code = _countryCode;
-    String phone = phoneController.text.trim();
-    String password = passwordController.text.trim();
-    if (phone.isEmpty) {
-      showCustomSnackBarHelper('please_give_your_phone_number'.tr,  isError: true);
-    } else if (password.isEmpty) {
-      showCustomSnackBarHelper('please_enter_your_valid_pin'.tr,  isError: true);
-    } else if (password.length != 4) {
-      showCustomSnackBarHelper('pin_should_be_4_digit'.tr, isError: true);
-    } else {
-
-      try{
-        await  Get.find<AuthController>().setUserData(UserShortDataModel(phone: phone, countryCode: _countryCode));
-
-        Get.find<AuthController>().login(code: code!, phone: phone,password: password).then((value) async{
-          if(value.isOk){
-            // await Get.find<ProfileController>().getProfileData(reload: true);
-          }
-        });
-      }catch(e){
-        showCustomSnackBarHelper('please_input_your_valid_number'.tr,isError: true);
-      }
+  void _submit() {
+    final email = emailController.text.trim();
+    final password = passwordController.text.trim();
+    if (email.isNotEmpty && password.isNotEmpty) {
+      Get.find<DesktopAuthController>().login(email: email, password: password, rememberMe: rememberMe);
     }
   }
 }

--- a/lib/features/auth/utils/auth_error_handler.dart
+++ b/lib/features/auth/utils/auth_error_handler.dart
@@ -1,0 +1,9 @@
+class AuthErrorHandler {
+  static void handleLoginError(dynamic error) {
+    // Placeholder for login error handling
+  }
+
+  static void handleTokenRefreshError(dynamic error) {
+    // Placeholder for token refresh error handling
+  }
+}

--- a/lib/features/auth/widgets/logout_dialog.dart
+++ b/lib/features/auth/widgets/logout_dialog.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+class LogoutDialog extends StatelessWidget {
+  final bool showLogoutAllOption;
+  const LogoutDialog({super.key, this.showLogoutAllOption = false});
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Logout'),
+      content: const Text('Choose logout option'),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop('current'),
+          child: const Text('This device'),
+        ),
+        if (showLogoutAllOption)
+          TextButton(
+            onPressed: () => Navigator.of(context).pop('all'),
+            child: const Text('All devices'),
+          ),
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/auth/widgets/session_monitor_widget.dart
+++ b/lib/features/auth/widgets/session_monitor_widget.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import '../controllers/desktop_auth_controller.dart';
+
+class SessionMonitorWidget extends StatelessWidget {
+  const SessionMonitorWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Obx(() {
+      final controller = Get.find<DesktopAuthController>();
+      final remaining = controller.remainingSeconds.value;
+      if (remaining > 0 && remaining < 120) {
+        return SessionWarningBanner(
+          remainingSeconds: remaining,
+          onExtendSession: () => controller.refreshToken(),
+        );
+      }
+      return const SizedBox.shrink();
+    });
+  }
+}
+
+class SessionWarningBanner extends StatelessWidget {
+  final int remainingSeconds;
+  final VoidCallback onExtendSession;
+  const SessionWarningBanner({super.key, required this.remainingSeconds, required this.onExtendSession});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: Colors.orange,
+      padding: const EdgeInsets.all(8),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text('Session expires in \$remainingSeconds seconds'),
+          TextButton(onPressed: onExtendSession, child: const Text('Extend')),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/helper/route_helper.dart
+++ b/lib/helper/route_helper.dart
@@ -195,5 +195,23 @@
 //         phoneNumber: utf8.decode(base64Url.decode(Get.parameters['phone-number']!.replaceAll(' ', '+'))),)),
 
 //     ];
-
 // }
+
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import '../features/auth/controllers/desktop_auth_controller.dart';
+
+class RouteHelper {
+  static final middlewares = [
+    GetMiddleware(
+      priority: 0,
+      redirect: (route) {
+        final isAuthenticated = Get.find<DesktopAuthController>().isAuthenticated.value;
+        if (route?.settings.name == '/dashboard' && !isAuthenticated) {
+          return const RouteSettings(name: '/login');
+        }
+        return null;
+      },
+    ),
+  ];
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,6 +23,10 @@ import 'package:uuid/uuid.dart';
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:sanaa_fi_saas/helper/network_info.dart';
+import 'package:desktop_window/desktop_window.dart';
+import 'dart:io';
+import 'features/auth/controllers/desktop_auth_controller.dart';
+import 'data/repository/auth_repo.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -30,6 +34,11 @@ Future<void> main() async {
   // Initialize GetStorage and SharedPreferences
   await GetStorage.init();
   final SharedPreferences sharedPreferences = await SharedPreferences.getInstance();
+
+  if (Platform.isWindows || Platform.isLinux || Platform.isMacOS) {
+    await DesktopWindow.setWindowSize(const Size(1280, 720));
+    await DesktopWindow.setMinWindowSize(const Size(800, 600));
+  }
 
   // Get device info and generate uniqueId
   final BaseDeviceInfo deviceInfo = await DeviceInfoPlugin().deviceInfo;
@@ -42,6 +51,9 @@ Future<void> main() async {
         deiceInfo: deviceInfo,
         uniqueId: uniqueId,
       ));
+
+  Get.lazyPut<AuthRepo>(() => AuthRepo(apiClient: Get.find<ApiClient>(), sharedPreferences: sharedPreferences));
+  Get.put(DesktopAuthController(authRepo: Get.find<AuthRepo>()));
 
  
 
@@ -82,9 +94,8 @@ Future<void> main() async {
   final networkInfo = Get.put(NetworkInfo(Connectivity()));
   networkInfo.initConnectionCheck();
 
-
-
-
+  final desktopAuth = Get.find<DesktopAuthController>();
+  await desktopAuth.checkExistingSession();
 
   runApp(MyApp());
 }

--- a/lib/services/desktop_session_storage.dart
+++ b/lib/services/desktop_session_storage.dart
@@ -1,0 +1,43 @@
+import 'package:get_storage/get_storage.dart';
+import 'package:sanaa_fi_saas/utils/app_constants.dart';
+
+class SessionData {
+  final String token;
+  final int sessionId;
+  final String email;
+  SessionData({required this.token, required this.sessionId, required this.email});
+}
+
+class DesktopSessionStorage {
+  static const _tokenKey = AppConstants.desktopAuthToken;
+  static const _sessionIdKey = AppConstants.desktopSessionId;
+  static const _emailKey = AppConstants.desktopUserEmail;
+  static final _storage = GetStorage();
+
+  static Future<void> saveSession(String token, int sessionId, String email) async {
+    await _storage.write(_tokenKey, token);
+    await _storage.write(_sessionIdKey, sessionId);
+    await _storage.write(_emailKey, email);
+  }
+
+  static Future<SessionData?> getSession() async {
+    final token = _storage.read<String>(_tokenKey);
+    final id = _storage.read<int>(_sessionIdKey);
+    final email = _storage.read<String>(_emailKey);
+    if (token != null && id != null && email != null) {
+      return SessionData(token: token, sessionId: id, email: email);
+    }
+    return null;
+  }
+
+  static Future<void> clearSession() async {
+    await _storage.remove(_tokenKey);
+    await _storage.remove(_sessionIdKey);
+    await _storage.remove(_emailKey);
+  }
+
+  static Future<bool> hasValidSession() async {
+    final data = await getSession();
+    return data != null;
+  }
+}

--- a/lib/services/device_fingerprint_service.dart
+++ b/lib/services/device_fingerprint_service.dart
@@ -1,0 +1,40 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:crypto/crypto.dart';
+import 'package:device_info_plus/device_info_plus.dart';
+import 'package:get_storage/get_storage.dart';
+import 'package:sanaa_fi_saas/utils/app_constants.dart';
+
+class DeviceFingerprintService {
+  static final _storage = GetStorage();
+
+  static Future<String> generateFingerprint() async {
+    final info = DeviceInfoPlugin();
+    String deviceId = '';
+    if (Platform.isWindows) {
+      final data = await info.windowsInfo;
+      deviceId = data.deviceId ?? '';
+    } else if (Platform.isLinux) {
+      final data = await info.linuxInfo;
+      deviceId = data.machineId ?? '';
+    } else if (Platform.isMacOS) {
+      final data = await info.macOsInfo;
+      deviceId = data.systemGUID ?? '';
+    }
+    final platform = Platform.operatingSystem;
+    final name = Platform.localHostname;
+    final mac = '';
+    final raw = '$deviceId|$platform|$name|$mac';
+    final hash = sha256.convert(utf8.encode(raw)).toString();
+    await storeFingerprint(hash);
+    return hash;
+  }
+
+  static Future<void> storeFingerprint(String fingerprint) async {
+    await _storage.write(AppConstants.deviceFingerprint, fingerprint);
+  }
+
+  static Future<String?> getStoredFingerprint() async {
+    return _storage.read(AppConstants.deviceFingerprint);
+  }
+}

--- a/lib/utils/app_constants.dart
+++ b/lib/utils/app_constants.dart
@@ -88,6 +88,14 @@ static const String payLoan = '/api/v1/loans/pay';
   static const String withdrawRequest = '/api/v1/customer/withdraw';
   static const String getWithdrawalRequest = '/api/v1/customer/withdrawal-requests';
 
+  // Desktop authentication endpoints
+  static const String desktopLogin = '/desktop-api/login';
+  static const String desktopLogout = '/desktop-api/logout';
+  static const String desktopLogoutAll = '/desktop-api/logout-all';
+  static const String desktopRefresh = '/desktop-api/refresh';
+  static const String desktopVerify = '/desktop-api/verify';
+  static const String desktopSession = '/desktop-api/session';
+
 
   // Shared Key
   static const String theme = 'theme';
@@ -116,6 +124,12 @@ static const String payLoan = '/api/v1/loans/pay';
   static const String biometricPin = 'biometric';
   static const String contactPermission = '';
   static const String userData = 'user';
+
+  // Desktop session storage keys
+  static const String desktopAuthToken = 'desktop_auth_token';
+  static const String desktopSessionId = 'desktop_session_id';
+  static const String desktopUserEmail = 'desktop_user_email';
+  static const String deviceFingerprint = 'device_fingerprint';
 
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,6 +32,7 @@ dependencies:
   # firebase_messaging: ^14.4.1
   unique_identifier: ^0.3.0
   device_info_plus: ^10.1.2
+  crypto: ^3.0.3
   app_settings: ^5.1.1
   phone_number: ^2.1.0
   connectivity_plus: ^6.0.5


### PR DESCRIPTION
## Summary
- define desktop endpoints and storage keys
- extend `AuthRepo` with desktop auth methods
- add `DesktopAuthController` with session monitoring and refresh logic
- create device fingerprint and session storage utilities
- provide basic desktop login screen and widgets
- update `ApiClient` and app initialization for desktop auth

## Testing
- `dart pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68617d70e5808324842dbb3bd8e8d4e2