### PR TITLE
Fix loans dashboard controller naming

### DIFF
--- a/lib/features/Loans/controllers/loans_dashboard_controller.dart
+++ b/lib/features/Loans/controllers/loans_dashboard_controller.dart
@@ -6,10 +6,10 @@ import 'package:sanaa_fi_saas/features/Loans/data/loansRepo.dart';
 // import 'package:sanaa_fi_saas/models/dashboard_stats.dart';
 // import 'package:sanaa_fi_saas/repositories/loan_repo.dart';
 
-class DashboardController extends GetxController {
+class LoansDashboardController extends GetxController {
   final LoanRepo loanRepo;
 
-  DashboardController({required this.loanRepo});
+  LoansDashboardController({required this.loanRepo});
 
   // Observable variables
   var totalClients = 0.obs;

--- a/lib/features/Loans/views/loansWidgets.dart
+++ b/lib/features/Loans/views/loansWidgets.dart
@@ -94,7 +94,7 @@ class LoansPlansPage extends StatelessWidget {
 
 class LoansHome extends StatelessWidget {
   LoansHome({super.key});
-  final DashboardController controller = Get.find<DashboardController>();
+  final LoansDashboardController controller = Get.find<LoansDashboardController>();
 
   @override
   Widget build(BuildContext context) {
@@ -189,7 +189,7 @@ class LoansHome extends StatelessWidget {
 
 class LoansHome10 extends StatelessWidget {
    LoansHome10({super.key});
- final DashboardController controller = Get.find<DashboardController>();
+ final LoansDashboardController controller = Get.find<LoansDashboardController>();
 
   @override
   Widget build(BuildContext context) {
@@ -325,7 +325,7 @@ class LoansHome10 extends StatelessWidget {
 
 class DashboardMetricItems extends StatelessWidget {
    DashboardMetricItems({super.key});
-  final DashboardController controller = Get.find<DashboardController>();
+  final LoansDashboardController controller = Get.find<LoansDashboardController>();
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
## Summary
- rename `DashboardController` to `LoansDashboardController`
- update views and injection to use the new controller name

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861c48f19048324bd1c72153c1bb196